### PR TITLE
Removes react/forbid-prop-types rule.

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -6,7 +6,6 @@ module.exports = {
         }
     ],
     'react/forbid-component-props': 'error',
-    'react/forbid-prop-types': 'error',
     'react/jsx-boolean-value': 'error',
     'react/jsx-closing-bracket-location': 'error',
     'react/jsx-curly-spacing': 'error',


### PR DESCRIPTION
While I like the premise behind [react/forbid-prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md), in practice, it can be more difficult to enforce, especially when storing third party api results in your store.

That, and once you start using `shape`, it's a rabbit hole requiring you to define the shape 🐢's all the way down. Again, this gets complicated with third party api results.

For these reasons, I suggest removing the rule. 