### PR TITLE
Removes react/jsx-no-bind rule.

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -27,7 +27,6 @@ module.exports = {
     'react/jsx-indent-props': 'error',
     'react/jsx-key': 'error',
     'react/jsx-max-props-per-line': 'error',
-    'react/jsx-no-bind': 'error',
     'react/jsx-no-comment-textnodes': 'error',
     'react/jsx-no-duplicate-props': [
         'error',


### PR DESCRIPTION
While I like the intent behind [react/jsx-no-bind](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md), it feels like a pre mature optimization. I have never seen performance issues with anonymous arrow functions used within jsx.

I also don't like the alternatives of using `ref` or creating a class versus a stateless functional component as work arounds.