### PR TITLE
Removes `import/prefer-default-export` and `import/no-namespace` rules.

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -24,6 +24,5 @@ module.exports = {
         {
             'newlines-between': 'always'
         }
-    ],
-    'import/prefer-default-export': 'error'
+    ]
 };

--- a/src/import.js
+++ b/src/import.js
@@ -15,7 +15,6 @@ module.exports = {
     'import/no-mutable-exports': 'error',
     'import/no-named-as-default': 'error',
     'import/no-named-as-default-member': 'error',
-    'import/no-namespace': 'error',
     'import/no-unassigned-import': 'error',
     'import/no-unresolved': 'error',
     'import/no-webpack-loader-syntax': 'error',


### PR DESCRIPTION
Removes a couple of import rules.

In both cases, they are ideal, but tough to enforce. Developers should us common sense without forcing people to do things.

**`import/prefer-default-export`**

While an ideal rule, it's not good for things like api abstractions where multiple functions are exported and there is no clear default.

**`import/no-namespace`**

Also an ideal rule, but it's not good for things like api abstractions where you want to use multiple functions and have them imported as `import * as api from './api'`.