### PR TITLE
Removes `class-methods-use-this` rule.

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -14,7 +14,6 @@ module.exports = {
     'brace-style': 'error',
     'callback-return': 'error',
     'camelcase': 'error',
-    'class-methods-use-this': 'error',
     'comma-dangle': 'error',
     'comma-spacing': 'error',
     'comma-style': 'error',


### PR DESCRIPTION
The [class-methods-use-this](http://eslint.org/docs/rules/class-methods-use-this) rule doesn't play nicely with React class components.