### PR TITLE
Removes `global-require` rule.

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -38,7 +38,6 @@ module.exports = {
     ],
     'func-call-spacing': 'error',
     'generator-star-spacing': 'error',
-    'global-require': 'error',
     'guard-for-in': 'error',
     'handle-callback-err': 'error',
     'indent': [


### PR DESCRIPTION
The [global-require](http://eslint.org/docs/rules/global-require) rule doesn't work well when requiring css / sass files in React's `componentDidMount` when trying to create isomorphic components.

For example:

```js
class Root extends React.Component {
    componentDidMount() {
        require('./Root.scss'); // <-- Doesn't like this line.
    }

    render() {
        return (
            <Provider store={this.props.store}>
                <App />
            </Provider>
        );
    }
}
```