### PR TITLE
Removes `import/no-unassigned-import` rule.

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -15,7 +15,6 @@ module.exports = {
     'import/no-mutable-exports': 'error',
     'import/no-named-as-default': 'error',
     'import/no-named-as-default-member': 'error',
-    'import/no-unassigned-import': 'error',
     'import/no-unresolved': 'error',
     'import/no-webpack-loader-syntax': 'error',
     'import/order': [


### PR DESCRIPTION
The [import/no-unassigned-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md) rule doesn't work for some node modules that automatically work simply by importing, but it also doesn't work well when requiring css / sass files in React's `componentDidMount` when trying to create isomorphic components.

For example:

```js
class Root extends React.Component {
    componentDidMount() {
        require('./Root.scss'); // <-- Doesn't like this line.
    }

    render() {
        return (
            <Provider store={this.props.store}>
                <App />
            </Provider>
        );
    }
}
```