### PR TITLE
Fixes rule conflict between `no-extra-parens` and `react/jsx-wrap-multilines`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "babel-eslint": "6.1.2",
-    "eslint": "3.7.0",
+    "eslint": "3.15.0",
     "eslint-plugin-import": "2.0.0",
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-mocha": "4.5.1",

--- a/src/eslint.js
+++ b/src/eslint.js
@@ -125,7 +125,10 @@ module.exports = {
     'no-extra-label': 'error',
     'no-extra-parens': [
         'error',
-        'all'
+        'all',
+        {
+            ignoreJSX: 'multi-line'
+        }
     ],
     'no-extra-semi': 'error',
     'no-fallthrough': 'error',


### PR DESCRIPTION
Tested using the following with no conflicts.

```js
const assignment = (
    <div>
        <p>{'Hello'}</p>
    </div>
);

const StatelessFunctionalComponent = ({previous, previousTo, title}) =>
    <div>
        <p>{'Hello'}</p>
    </div>;

const CreateClassComponent = React.createClass({
    render: function () {
        return (
            <div>
                <p>{'Hello'}</p>
            </div>
        );
    }
});

class Es6ClassComponent extends React.Component {
    render() {
        return (
            <div>
                <p>{'Hello'}</p>
            </div>
        );
    }
}
```

#22 was created to make up for the gap in eslint rules between versions.

Fixes #19