### PR TITLE
Changes `react/display-name` rule to not error on intuitive or automatic determinable names.

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -2,7 +2,7 @@ module.exports = {
     'react/display-name': [
         'error',
         {
-            ignoreTranspilerName: true
+            ignoreTranspilerName: false
         }
     ],
     'react/forbid-component-props': 'error',


### PR DESCRIPTION
Tested rule change with the following scenarios.

### Passes

The following usages will pass lint as the component display name is able to be intuitively or automatically determined.

```js
const CreateClassComponent = React.createClass({
    render: function () {
        return (
            <div>
                <p>{'Hello'}</p>
            </div>
        );
    }
});

export default CreateClassComponent;
```

```js
export default class Es6ClassComponent extends React.Component {
    render() {
        return (
            <div>
                <p>{'Hello'}</p>
            </div>
        );
    }
}
```

```js
const StatelessFunctionalComponent = () =>
    <div>
        <p>{'Hello'}</p>
    </div>;

export default StatelessFunctionalComponent;
```

### Fails

The following usages will fail lint as the component display name is not able to be intuitively or automatically determined.

```js
export default () =>
    <div>
        <p>{'Hello'}</p>
    </div>;
```

```js
export default React.createClass({
    render: function () {
        return (
            <div>
                <p>{'Hello'}</p>
            </div>
        );
    }
});
```

Fixes #24