### PR TITLE
Fixes eslint running super slow on larger projects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "babel-eslint": "6.1.2",
     "eslint": "3.7.0",
-    "eslint-plugin-import": "2.0.0",
+    "eslint-plugin-import": "2.2.0",
     "eslint-plugin-json": "1.2.0",
     "eslint-plugin-mocha": "4.5.1",
     "eslint-plugin-node": "2.1.2",


### PR DESCRIPTION
Tested this locally with one of our projects that was taking ~54 seconds to run eslint.

After the version bump, the time decreased to ~6 seconds.

#27 was created to make up for the gap in eslint-import-plugin rules between versions.

Fixes #20 