### PR TITLE
Changes `import/namespace` to allow computed values.

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -4,7 +4,12 @@ module.exports = {
     'import/extensions': 'error',
     'import/first': 'error',
     'import/named': 'error',
-    'import/namespace': 'error',
+    'import/namespace': [
+        'error',
+        {
+            allowComputed: true
+        }
+    ],
     'import/newline-after-import': 'error',
     'import/no-absolute-path': 'error',
     'import/no-amd': 'error',


### PR DESCRIPTION
Relaxing the [import/namespace](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md) rule to allow for computed values.