### PR TITLE
Removes `mocha/no-hooks-for-single-case` rule.

### DIFF
--- a/src/mocha.js
+++ b/src/mocha.js
@@ -2,7 +2,6 @@ module.exports = {
     'mocha/handle-done-callback': 'error',
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-global-tests': 'error',
-    'mocha/no-hooks-for-single-case': 'error',
     'mocha/no-identical-title': 'error',
     'mocha/no-pending-tests': 'error',
     'mocha/no-return-and-callback': 'error',


### PR DESCRIPTION
While the [mocha/no-hooks-for-single-case](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-hooks-for-single-case.md) makes sense from a logical standpoint, when most of your other tests have a `beforeEach` and `afterEach` flow to them, forcing the setup into the actual `it` feels heavy handed and introduces inconsistency in the test writing flow.