### PR TITLE
Removes `react/jsx-handler-names` rule.

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -22,7 +22,6 @@ module.exports = {
         'error',
         'multiline'
     ],
-    'react/jsx-handler-names': 'error',
     'react/jsx-indent': 'error',
     'react/jsx-indent-props': 'error',
     'react/jsx-key': 'error',


### PR DESCRIPTION
The [react/jsx-handler-names](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md) rule is nice from a consistency standpoint, however, devs are not always in control of what the handler name is, as #29 points out.

Fixes #29 
