### PR TITLE
Removes `react/forbid-component-props` rule.

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -5,7 +5,6 @@ module.exports = {
             ignoreTranspilerName: true
         }
     ],
-    'react/forbid-component-props': 'error',
     'react/jsx-boolean-value': 'error',
     'react/jsx-closing-bracket-location': 'error',
     'react/jsx-curly-spacing': 'error',


### PR DESCRIPTION
While [react/forbid-component-props](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md) is ideal in theory, a dev is not always in control of the component it needs to interact with.

Take react-router's `<Link>`, for example. 

If we want to do some styling to it, we either need to pass it inline styles or give it  a `className` so we can style it.

As such, removing the rule seems to make the most sense.