### PR TITLE
Removes `no-invalid-this` rule.

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -147,7 +147,6 @@ module.exports = {
             ]
         }
     ],
-    'no-invalid-this': 'error',
     'no-irregular-whitespace': 'error',
     'no-iterator': 'error',
     'no-label-var': 'error',


### PR DESCRIPTION
The [no-invalid-this](http://eslint.org/docs/rules/no-invalid-this) is nice in that it limits the abuse of `this`, however, when paired with writing ES6 classes, it can cause extra logic that is either not as performant or unnecessarily verbose and borderline unreadable.

Given both of those options, I'd rather not use the rule at all.