### PR TITLE
Removes `no-confusing-arrow` rule.

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -88,7 +88,6 @@ module.exports = {
         'error',
         'always'
     ],
-    'no-confusing-arrow': 'error',
     'no-console': 'error',
     'no-const-assign': 'error',
     'no-constant-condition': [


### PR DESCRIPTION
Contrary to it's name, using arrow functions in implicit return statements doesn't look that confusing. 

Base on that, we're suggesting to remove the rule completely. 