### PR TITLE
Removes eslint-plugin-chai-expect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This config also comes with the following plugins, and corresponding rules, bake
 
 * [babel-eslint](https://www.npmjs.com/package/babel-eslint)
 * [eslint](https://www.npmjs.com/package/eslint)
-* [eslint-plugin-chai-expect](https://www.npmjs.com/package/eslint-plugin-chai-expect)
 * [eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments)
 * [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
 * [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const chaiExpect = require('./src/chai-expect');
 const eslint = require('./src/eslint');
 const eslintComments = require('./src/eslint-comments');
 const imprt = require('./src/import');
@@ -30,7 +29,6 @@ module.exports = {
         sourceType: 'module'
     },
     plugins: [
-        'chai-expect',
         'eslint-comments',
         'import',
         'jest',
@@ -45,7 +43,6 @@ module.exports = {
         'unicorn'
     ],
     rules: {
-        ...chaiExpect,
         ...eslint,
         ...eslintComments,
         ...imprt,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "babel-eslint": "8.0.2",
     "eslint": "4.11.0",
-    "eslint-plugin-chai-expect": "1.1.1",
     "eslint-plugin-eslint-comments": "2.0.1",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jest": "21.3.2",

--- a/src/chai-expect.js
+++ b/src/chai-expect.js
@@ -1,5 +1,0 @@
-module.exports = {
-    'chai-expect/missing-assertion': 'error',
-    'chai-expect/no-inner-compare': 'error',
-    'chai-expect/terminating-properties': 'error'
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,10 +454,6 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-chai-expect@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz#cd640b8b38cf6c3abcc378673b7b173b99ddc70a"
-
 eslint-plugin-eslint-comments@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-2.0.1.tgz#2cddd5507f1f93b6738b5295f1730f4c2712f2a3"


### PR DESCRIPTION
We're favoring Jest in our testing now, so we're not longer using chai.