### PR TITLE
Upgrade eslint-plugin-eslint-comments to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "babel-eslint": "8.2.2",
-    "eslint-plugin-eslint-comments": "2.0.2",
+    "eslint-plugin-eslint-comments": "3.0.1",
     "eslint-plugin-get-off-my-lawn": "1.0.2",
     "eslint-plugin-import": "2.10.0",
     "eslint-plugin-jest": "21.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,12 +512,12 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-eslint-comments@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-2.0.2.tgz#006e1c834beffe6ff3014e84a3ae69acfa539a28"
+eslint-plugin-eslint-comments@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.0.1.tgz#baafb713584c0de7ee588710720e580bcc28cfbb"
   dependencies:
     escape-string-regexp "^1.0.5"
-    ignore "^3.3.7"
+    ignore "^3.3.8"
 
 eslint-plugin-get-off-my-lawn@1.0.2:
   version "1.0.2"
@@ -888,6 +888,10 @@ iconv-lite@^0.4.17, iconv-lite@~0.4.13:
 ignore@^3.3.3, ignore@^3.3.6, ignore@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+ignore@^3.3.8:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
 import-modules@1.1.0, import-modules@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
For context, I installed this alongside `eslint@v5.9.0`; even though the peer dep version is [` >=4.19.1`](https://github.com/manovotny/eslint-config-get-off-my-lawn/blob/442de85554a81f1f5a0e3f7db28b2bd3023a9423/package.json#L58), things worked fine with the exception of [this issue](https://github.com/mysticatea/eslint-plugin-eslint-comments/issues/12) in `eslint-plugin-eslint-comments`.

Upgrading to the latest version fixed the issue. I took a glance at the [changelog](https://github.com/mysticatea/eslint-plugin-eslint-comments/releases) and the only thing that jumped out at me was: 
>Now plugin:eslint-comments/recommended preset doesn't include eslint-comments/no-unused-disable rule. 

Fortunately the rule was already explicitly configured, so it still error'd for me locally.
