### PR TITLE
Removes `unicorn/filename-case` rule.

### DIFF
--- a/src/unicorn.js
+++ b/src/unicorn.js
@@ -3,15 +3,6 @@ module.exports = {
     'unicorn/custom-error-definition': 'error',
     'unicorn/error-message': 'error',
     'unicorn/escape-case': 'error',
-    'unicorn/filename-case': [
-        'error',
-        {
-            cases: {
-                kebabCase: true,
-                pascalCase: true
-            }
-        }
-    ],
     'unicorn/new-for-builtins': 'error',
     'unicorn/no-abusive-eslint-disable': 'error',
     'unicorn/no-array-instanceof': 'error',


### PR DESCRIPTION
The rule wasn't working for our use cases.

Will evaluate future adoption in #123.

Fixes #121