### PR TITLE
Removes prefer-named-capture-group rule.

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -265,7 +265,6 @@ module.exports = {
     'padding-line-between-statements': ['error', ...linebreaks],
     'prefer-const': 'error',
     'prefer-exponentiation-operator': 'error',
-    'prefer-named-capture-group': 'error',
     'prefer-numeric-literals': 'error',
     'prefer-object-spread': 'error',
     'prefer-regex-literals': 'error',


### PR DESCRIPTION
After trying this out on a few repos, I've found it does the opposite of what the rule intends to fix... It actually makes already complex regexes _more_ difficult to read instead of _easier_ to understand. 