### PR TITLE
fix: remove forward slashes from https suggest

### DIFF
--- a/src/unicorn.js
+++ b/src/unicorn.js
@@ -71,7 +71,7 @@ module.exports = {
             patterns: {
                 '(?!(?=.*(localhost|0.0.0.0|127.0.0.1)))^http:': {
                     message: 'Please use `https` for better security.`.',
-                    suggest: 'https://',
+                    suggest: 'https:',
                 },
             },
         },

--- a/src/unicorn.test.js
+++ b/src/unicorn.test.js
@@ -4,7 +4,7 @@ describe('unicorn/string-content', () => {
     const patterns = Object.entries(unicorn['unicorn/string-content'][1].patterns);
 
     patterns.forEach(([key, value]) => {
-        if (value.suggest === 'https://') {
+        if (value.suggest === 'https:') {
             const regex = new RegExp(key, 'u');
 
             describe('https', () => {


### PR DESCRIPTION
When performing replacement with the suggestion, we end up with four forward slashes.