### PR TITLE
Updates to ESlint 8.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1331,14 +1331,14 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-            "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz",
+            "integrity": "sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
-                "debug": "^4.1.1",
-                "espree": "^7.3.0",
+                "debug": "^4.3.2",
+                "espree": "^9.0.0",
                 "globals": "^13.9.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
@@ -1347,10 +1347,19 @@
                 "strip-json-comments": "^3.1.1"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
                 "globals": {
-                    "version": "13.11.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-                    "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+                    "version": "13.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+                    "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
                     "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
@@ -1371,9 +1380,9 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-            "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
+            "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.0",
@@ -3433,37 +3442,36 @@
             }
         },
         "eslint": {
-            "version": "7.32.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-            "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.1.0.tgz",
+            "integrity": "sha512-JZvNneArGSUsluHWJ8g8MMs3CfIEzwaLx9KyH4tZ2i+R2/rPWzL8c0zg3rHdwYVpN/1sB9gqnjHwz9HoeJpGHw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.12.11",
-                "@eslint/eslintrc": "^0.4.3",
-                "@humanwhocodes/config-array": "^0.5.0",
+                "@eslint/eslintrc": "^1.0.3",
+                "@humanwhocodes/config-array": "^0.6.0",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
-                "debug": "^4.0.1",
+                "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "enquirer": "^2.3.5",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^2.1.0",
-                "eslint-visitor-keys": "^2.0.0",
-                "espree": "^7.3.1",
+                "eslint-scope": "^6.0.0",
+                "eslint-utils": "^3.0.0",
+                "eslint-visitor-keys": "^3.0.0",
+                "espree": "^9.0.0",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.1.2",
+                "glob-parent": "^6.0.1",
                 "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "^3.13.1",
+                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
@@ -3471,22 +3479,27 @@
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
                 "progress": "^2.0.0",
-                "regexpp": "^3.1.0",
+                "regexpp": "^3.2.0",
                 "semver": "^7.2.1",
                 "strip-ansi": "^6.0.0",
                 "strip-json-comments": "^3.1.0",
-                "table": "^6.0.9",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.10.4"
+                        "ms": "2.1.2"
                     }
                 },
                 "doctrine": {
@@ -3504,16 +3517,63 @@
                     "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
                     "dev": true
                 },
+                "eslint-scope": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
+                    "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^5.2.0"
+                    }
+                },
+                "eslint-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+                    "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "eslint-visitor-keys": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                            "dev": true
+                        }
+                    }
+                },
                 "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+                    "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
                     "dev": true
                 },
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.3"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "4.0.3",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+                            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "^2.1.1"
+                            }
+                        }
+                    }
+                },
                 "globals": {
-                    "version": "13.11.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-                    "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+                    "version": "13.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+                    "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
                     "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
@@ -3523,6 +3583,21 @@
                     "version": "4.0.6",
                     "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
                     "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
+                },
+                "regexpp": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+                    "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
                     "dev": true
                 },
                 "type-fest": {
@@ -4010,14 +4085,28 @@
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
         },
         "espree": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-            "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+            "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
             "dev": true,
             "requires": {
-                "acorn": "^7.4.0",
+                "acorn": "^8.5.0",
                 "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^1.3.0"
+                "eslint-visitor-keys": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.5.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+                    "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+                    "dev": true
+                },
+                "eslint-visitor-keys": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+                    "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
@@ -5957,22 +6046,10 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
             "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-            "dev": true
-        },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "lodash.truncate": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
             "dev": true
         },
         "log-symbols": {
@@ -7318,12 +7395,6 @@
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true
         },
-        "require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true
-        },
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -7788,40 +7859,6 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
-        },
-        "table": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-            "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
-            "dev": true,
-            "requires": {
-                "ajv": "^8.0.1",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "8.6.3",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-                    "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "json-schema-traverse": "^1.0.0",
-                        "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
-                }
-            }
         },
         "term-size": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
         "prettier-config-get-off-my-lawn": "1.0.0"
     },
     "peerDependencies": {
-        "eslint": ">=7.32.0"
+        "eslint": ">=8.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     },
     "devDependencies": {
         "@vercel/git-hooks": "1.0.0",
-        "eslint": "7.32.0",
+        "eslint": "8.1.0",
         "jest": "27.3.1",
         "lint-staged": "11.2.6",
         "npm-check": "5.9.2",

--- a/src/eslint.js
+++ b/src/eslint.js
@@ -236,6 +236,7 @@ module.exports = {
     ],
     'no-unused-expressions': 'error',
     'no-unused-labels': 'error',
+    'no-unused-private-class-members': 'error',
     'no-unused-vars': [
         'error',
         {


### PR DESCRIPTION
_This is currently based on the `v7` branch (#173), but could be switched to `main` if `v7` get's merged first._

Updates to [ESLint 8](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0).

There's a few dependencies that need to be updated before this can be nicely merged (we can get forceful if need be, but giving the ecosystem time to adopt).

- [ ] eslint-plugin-jsx-a11y
    - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/pull/810
- [ ] eslint-plugin-react
    - https://github.com/yannickcr/eslint-plugin-react/pull/3059
- [ ] eslint-plugin-react-hooks (merged, but [not released](https://github.com/facebook/react/pull/22248#issuecomment-940731956))
    - https://github.com/facebook/react/pull/22248
- [ ] eslint-plugin-react-native
    - https://github.com/Intellicode/eslint-plugin-react-native/pull/299