### PR TITLE
Fixes `unicorn/prefer-node-protocol` false positives.

### DIFF
--- a/src/unicorn.js
+++ b/src/unicorn.js
@@ -6,10 +6,10 @@ const {graphql, next} = require('./utils/dependencies');
 const nodeEnginesVersion = packageJson.engines?.node ? semver.minVersion(packageJson.engines.node).version : undefined;
 
 // https://nodejs.org/api/esm.html#node-imports
-// Known issue with node protocol and Next.js: https://github.com/vercel/next.js/issues/28774
 const nodeVersionSupportsNodeProtocolInImports = Boolean(
-    !next
-    //&& nodeEnginesVersion && semver.satisfies(nodeEnginesVersion, '^12.20.0 || ^14.13.1 || >=16.0.0')
+    // Known issue with node protocol and Next.js
+    // https://github.com/vercel/next.js/issues/28774
+    !next && nodeEnginesVersion && semver.satisfies(nodeEnginesVersion, '^12.20.0 || ^14.13.1 || >=16.0.0')
 );
 const nodeVersionSupportsNodeProtocolInRequires = Boolean(
     nodeEnginesVersion && semver.satisfies(nodeEnginesVersion, '^14.18.0 || >=16.0.0')

--- a/src/unicorn.test.js
+++ b/src/unicorn.test.js
@@ -19,23 +19,15 @@ describe('unicorn', () => {
         [
             {
                 expectedCheckRequire: false,
-                mockEnginesVersion: undefined,
+                mockEnginesVersion: '12.20.0',
             },
             {
                 expectedCheckRequire: false,
-                mockEnginesVersion: '10.0.0',
-            },
-            {
-                expectedCheckRequire: false,
-                mockEnginesVersion: '>=12.20.0',
+                mockEnginesVersion: '14.17.0',
             },
             {
                 expectedCheckRequire: true,
                 mockEnginesVersion: '~14.18.0',
-            },
-            {
-                expectedCheckRequire: false,
-                mockEnginesVersion: '^15.0.0',
             },
             {
                 expectedCheckRequire: true,
@@ -51,6 +43,51 @@ describe('unicorn', () => {
                 const [, {checkRequire}] = rules['unicorn/prefer-node-protocol'];
 
                 expect(checkRequire).toBe(expectedCheckRequire);
+            });
+        });
+
+        [
+            {
+                expectedToHaveRuleDefined: false,
+                mockEnginesVersion: undefined,
+            },
+            {
+                expectedToHaveRuleDefined: false,
+                mockEnginesVersion: '^10.0.0',
+            },
+            {
+                expectedToHaveRuleDefined: false,
+                mockEnginesVersion: '12.19.0',
+            },
+            {
+                expectedToHaveRuleDefined: false,
+                mockEnginesVersion: '13.0.0',
+            },
+            {
+                expectedToHaveRuleDefined: false,
+                mockEnginesVersion: '14.13.0',
+            },
+            {
+                expectedToHaveRuleDefined: true,
+                mockEnginesVersion: '14.13.1',
+            },
+            {
+                expectedToHaveRuleDefined: false,
+                mockEnginesVersion: '^15.0.0',
+            },
+            {
+                expectedToHaveRuleDefined: true,
+                mockEnginesVersion: '16.0.0',
+            },
+        ].forEach(({expectedToHaveRuleDefined, mockEnginesVersion}) => {
+            test(`to have rule defined; engines: ${mockEnginesVersion}`, () => {
+                jest.doMock('./utils/files/contents', () => ({
+                    packageJson: {engines: {node: mockEnginesVersion}},
+                }));
+
+                const {rules} = require('./unicorn');
+
+                expect(Object.hasOwn(rules, 'unicorn/prefer-node-protocol')).toBe(expectedToHaveRuleDefined);
             });
         });
 

--- a/src/unicorn.test.js
+++ b/src/unicorn.test.js
@@ -18,40 +18,31 @@ describe('unicorn', () => {
     describe('prefer-node-protocol', () => {
         [
             {
-                expectedCheckRequire: true,
-                mockEnginesVersion: undefined,
-                mockProcessVersion: '14.19.0',
-            },
-            {
-                expectedCheckRequire: true,
-                mockEnginesVersion: undefined,
-                mockProcessVersion: '14.18.0',
-            },
-            {
                 expectedCheckRequire: false,
                 mockEnginesVersion: undefined,
-                mockProcessVersion: '14.17.9',
             },
             {
                 expectedCheckRequire: false,
                 mockEnginesVersion: '10.0.0',
-                mockProcessVersion: '14.19.0',
             },
             {
                 expectedCheckRequire: false,
                 mockEnginesVersion: '>=12.20.0',
-                mockProcessVersion: '14.19.0',
+            },
+            {
+                expectedCheckRequire: true,
+                mockEnginesVersion: '~14.18.0',
+            },
+            {
+                expectedCheckRequire: false,
+                mockEnginesVersion: '^15.0.0',
             },
             {
                 expectedCheckRequire: true,
                 mockEnginesVersion: '^16.0.0',
-                mockProcessVersion: '14.19.0',
             },
-        ].forEach(({expectedCheckRequire, mockEnginesVersion, mockProcessVersion}) => {
-            test(`checkRequire; engines: ${mockEnginesVersion}; process: ${mockProcessVersion}`, () => {
-                jest.doMock('process', () => ({
-                    version: mockProcessVersion,
-                }));
+        ].forEach(({expectedCheckRequire, mockEnginesVersion}) => {
+            test(`checkRequire; engines: ${mockEnginesVersion}`, () => {
                 jest.doMock('./utils/files/contents', () => ({
                     packageJson: {engines: {node: mockEnginesVersion}},
                 }));
@@ -65,7 +56,7 @@ describe('unicorn', () => {
 
         test('should remove rule when using next', () => {
             jest.doMock('./utils/dependencies', () => ({
-                next: true,
+                next: '12.0.0',
             }));
 
             const {rules} = require('./unicorn');


### PR DESCRIPTION
* Dropped looking at `process.version`. `engines.node` in `package.json` is the only reliable way to know what a package intends to support.
* Add better node version range checking for supported versions.