### PR TITLE
Removes `jest/unbound-method`.

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -356,12 +356,8 @@ if (jestDependency) {
             // `expect` calls.
             // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/unbound-method.md
             '@typescript-eslint/unbound-method': 'off',
-            'jest/unbound-method': [
-                'error',
-                {
-                    ignoreStatic: true,
-                },
-            ],
+            // Purposely not enabling `jest/unbound-method` because it will complain about third-party packages that improperly use
+            // `this` and there's nothing you can do to fix it yourself.
         },
     });
 }


### PR DESCRIPTION
This rule was finding issues in third-party dependencies where you can do nothing to address the cause (ie. [config](https://www.npmjs.com/package/config)). Seems wiser to remove the rule than to constantly nag consumers.