### PR TITLE
Replaces semver `lt` and `gt` checks with `satisfies`.

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -257,7 +257,7 @@ const config = {
 
 // React version when hooks were added.
 // https://reactjs.org/docs/hooks-intro.html
-if (react && semver.lt(react, '16.8.0')) {
+if (react && semver.satisfies(react, '<16.8.0')) {
     config.plugins = config.plugins.filter((plugin) => plugin !== 'react-hooks');
     delete config.rules['react-hooks/exhaustive-deps'];
     delete config.rules['react-hooks/rules-of-hooks'];

--- a/src/react.test.js
+++ b/src/react.test.js
@@ -20,6 +20,11 @@ describe('react-hooks', () => {
             mockVersion: '16.7.9',
         },
         {
+            expectedIncludes: true,
+            expectedValue: 'error',
+            mockVersion: '^16.0.0',
+        },
+        {
             expectedIncludes: false,
             expectedValue: undefined,
             mockVersion: '15.1.2',

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -304,26 +304,26 @@ if (!react) {
     delete config.rules['react/jsx-filename-extension'];
 }
 
-if (typescript && semver.lt(typescript, '3.4.0')) {
+if (typescript && semver.satisfies(typescript, '<3.4.0')) {
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-as-const.md#when-not-to-use-it
     delete config.rules['@typescript-eslint/prefer-as-const'];
 }
 
-if (typescript && semver.lt(typescript, '3.7.0')) {
+if (typescript && semver.satisfies(typescript, '<3.7.0')) {
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md#when-not-to-use-it
     delete config.rules['@typescript-eslint/prefer-nullish-coalescing'];
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-optional-chain.md#when-not-to-use-it
     delete config.rules['@typescript-eslint/prefer-optional-chain'];
 }
 
-if (typescript && semver.lt(typescript, '3.8.0')) {
+if (typescript && semver.satisfies(typescript, '<3.8.0')) {
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-exports.md#when-not-to-use-it
     delete config.rules['@typescript-eslint/consistent-type-exports'];
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md#when-not-to-use-it
     delete config.rules['@typescript-eslint/consistent-type-imports'];
 }
 
-if (typescript && semver.lt(typescript, '3.9.0')) {
+if (typescript && semver.satisfies(typescript, '<3.9.0')) {
     // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md#when-not-to-use-it
     delete config.rules['@typescript-eslint/prefer-ts-expect-error'];
 }


### PR DESCRIPTION
`satisfies` will handle dependencies with ranges too  (ie. `~`, `^`, etc.).