### PR TITLE
Adds exception for `http://www.w3.org` to `https` rule.

### DIFF
--- a/src/unicorn.js
+++ b/src/unicorn.js
@@ -118,7 +118,7 @@ const config = {
             'error',
             {
                 patterns: {
-                    '(?!(?=.*(localhost|0.0.0.0|127.0.0.1)))^http:': {
+                    '(?!(?=.*(0.0.0.0|127.0.0.1|localhost|www.w3.org)))^http:': {
                         message: 'Please use `https` for better security.`.',
                         suggest: 'https:',
                     },

--- a/src/unicorn.test.js
+++ b/src/unicorn.test.js
@@ -151,6 +151,9 @@ describe('unicorn', () => {
                         'https://test.localhost',
                         'https://test.localhost/',
                         'https://test.localhost/path',
+                        // These are valid urls when working with html and svg.
+                        'http://www.w3.org/1999/xhtml',
+                        'http://www.w3.org/2000/svg',
                     ].forEach((url) => {
                         test(`valid url: ${url}`, () => {
                             const result = regex.test(url);


### PR DESCRIPTION
HTML and SVG namespaces (and probably more) use the perfectly valid `http://www.w3.org/*` value when creating documents. In fact, using `https` is invalid by most parsers.

This PR access an exception for all `http://www.w3.org` urls.

References:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html#attr-xmlns
* https://www.w3.org/TR/xml-names/#ns-decl
* https://www.w3.org/2000/svg