### PR TITLE
Fixes issues with trying to read an ESM Jest config.

### DIFF
--- a/src/utils/files/contents.js
+++ b/src/utils/files/contents.js
@@ -2,9 +2,22 @@ const {readJsonSync} = require('fs-extra');
 
 const locate = require('./locate');
 
-const packageJson = readJsonSync(locate('package.json'), {throws: false}) || {};
 const jestConfigLocation = locate(['jest.config.cjs', 'jest.config.js', 'jest.config.ts']);
-const jestConfig = jestConfigLocation ? require(jestConfigLocation) : {};
+
+const getJestConfig = () => {
+    if (jestConfigLocation) {
+        try {
+            require(jestConfigLocation);
+        } catch {
+            return {};
+        }
+    }
+
+    return {};
+};
+
+const packageJson = readJsonSync(locate('package.json'), {throws: false}) || {};
+const jestConfig = getJestConfig();
 const tsConfig = readJsonSync(locate('tsconfig.json'), {throws: false}) || {};
 
 module.exports = {


### PR DESCRIPTION
Crude work around of now until we figure out how to handle ESM as a whole.

If the Jest config is in ESM format and we cannot read it using `require` (which will throw an error because it doesn't understand `export default`), we'll just pretend we cannot read it and return an empty object. 